### PR TITLE
Initialize Nuxt SSR project for wedding invitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# SSR Wedding Invitation
+
+This project is a server-side rendered website for managing online wedding invitations. It is built with [Nuxt 3](https://nuxt.com), the SSR framework for Vue.js.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+## Build for Production
+
+```bash
+npm run build
+npm run start
+```
+
+## Lint
+
+```bash
+npm run lint
+```

--- a/app.vue
+++ b/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/components/InvitationCard.vue
+++ b/components/InvitationCard.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="max-w-md mx-auto bg-white shadow-lg rounded-lg p-8">
+    <h1 class="text-3xl font-bold mb-4">{{ couple }}</h1>
+    <p class="mb-2">You are cordially invited to the wedding celebration.</p>
+    <p class="text-sm text-gray-500">{{ date }} at {{ venue }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+const couple = 'Alex & Sam'
+const date = 'June 15, 2025'
+const venue = 'Sunset Gardens, Springfield'
+</script>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,20 @@
+import vue from 'eslint-plugin-vue'
+import prettier from 'eslint-config-prettier'
+
+export default [
+  {
+    ignores: ['node_modules']
+  },
+  {
+    files: ['**/*.{js,ts,vue}'],
+    languageOptions: {
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module'
+      }
+    },
+    plugins: { vue },
+    extends: ['eslint:recommended', 'plugin:vue/vue3-recommended', prettier],
+    rules: {}
+  }
+]

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,0 +1,11 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/tailwindcss', '@pinia/nuxt'],
+  css: ['~/assets/css/main.css'],
+  app: {
+    head: {
+      title: 'Wedding Invitation'
+    }
+  }
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ssr-wedding-invitation",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "start": "nuxt start",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "nuxt": "^3.11.2",
+    "@nuxtjs/tailwindcss": "^6.10.4",
+    "@pinia/nuxt": "^0.5.1",
+    "pinia": "^2.1.7",
+    "axios": "^1.6.7"
+  },
+  "devDependencies": {
+    "eslint": "^8.56.0",
+    "eslint-plugin-vue": "^9.24.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.0.0"
+  }
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-pink-50">
+    <InvitationCard />
+  </div>
+</template>
+
+<script setup lang="ts">
+import InvitationCard from '~/components/InvitationCard.vue'
+</script>

--- a/postcss.config.ts
+++ b/postcss.config.ts
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'tailwindcss'
+
+export default <Config>{
+  content: [
+    './components/**/*.{vue,js,ts}',
+    './pages/**/*.{vue,js,ts}',
+    './app.{vue,js,ts}',
+    './nuxt.config.{js,ts}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+}


### PR DESCRIPTION
## Summary
- bootstrap Nuxt 3 project for wedding invitations with Tailwind CSS and Pinia
- add invitation component and landing page
- configure Tailwind and PostCSS

## Testing
- `npm install` *(fails: 403 Forbidden from npm registry)*
- `npm run lint` *(fails: cannot find package 'eslint-plugin-vue')*

------
https://chatgpt.com/codex/tasks/task_e_689ee01d31148331ba40c42c9094d07c