### PR TITLE
Enhance invitation styling with elegant theme

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply font-serif text-gray-700;
+}

--- a/components/InvitationCard.vue
+++ b/components/InvitationCard.vue
@@ -1,13 +1,24 @@
 <template>
-  <div class="max-w-md mx-auto bg-white shadow-lg rounded-lg p-8">
-    <h1 class="text-3xl font-bold mb-4">{{ couple }}</h1>
-    <p class="mb-2">You are cordially invited to the wedding celebration.</p>
-    <p class="text-sm text-gray-500">{{ date }} at {{ venue }}</p>
+  <div
+    class="max-w-md mx-auto bg-white/80 backdrop-blur-sm shadow-xl rounded-lg p-8 ring-1 ring-rose-200 transform transition duration-300 hover:scale-105"
+  >
+    <h1 class="text-5xl font-script text-rose-600 mb-2 text-center">
+      {{ couple }}
+    </h1>
+    <div class="flex justify-center mb-4">
+      <span class="text-rose-300 text-2xl">❤︎ ❤︎ ❤︎</span>
+    </div>
+    <p class="mb-2 text-center text-gray-700">
+      You are cordially invited to the wedding celebration.
+    </p>
+    <p class="text-sm text-gray-500 text-center italic">
+      {{ date }} at {{ venue }}
+    </p>
   </div>
 </template>
 
 <script setup lang="ts">
-const couple = 'Alex & Sam'
-const date = 'June 15, 2025'
-const venue = 'Sunset Gardens, Springfield'
+const couple = "Alex & Sam";
+const date = "June 15, 2025";
+const venue = "Sunset Gardens, Springfield";
 </script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,11 +1,23 @@
-import { defineNuxtConfig } from 'nuxt/config'
+import { defineNuxtConfig } from "nuxt/config";
 
 export default defineNuxtConfig({
-  modules: ['@nuxtjs/tailwindcss', '@pinia/nuxt'],
-  css: ['~/assets/css/main.css'],
+  modules: ["@nuxtjs/tailwindcss", "@pinia/nuxt"],
+  css: ["~/assets/css/main.css"],
   app: {
     head: {
-      title: 'Wedding Invitation'
-    }
-  }
-})
+      title: "Wedding Invitation",
+      link: [
+        { rel: "preconnect", href: "https://fonts.googleapis.com" },
+        {
+          rel: "preconnect",
+          href: "https://fonts.gstatic.com",
+          crossorigin: "",
+        },
+        {
+          rel: "stylesheet",
+          href: "https://fonts.googleapis.com/css2?family=Great+Vibes&display=swap",
+        },
+      ],
+    },
+  },
+});

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,9 +1,11 @@
 <template>
-  <div class="min-h-screen flex items-center justify-center bg-pink-50">
+  <div
+    class="min-h-screen flex items-center justify-center bg-gradient-to-br from-rose-100 via-pink-50 to-rose-200"
+  >
     <InvitationCard />
   </div>
 </template>
 
 <script setup lang="ts">
-import InvitationCard from '~/components/InvitationCard.vue'
+import InvitationCard from "~/components/InvitationCard.vue";
 </script>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,14 +1,18 @@
-import type { Config } from 'tailwindcss'
+import type { Config } from "tailwindcss";
 
 export default <Config>{
   content: [
-    './components/**/*.{vue,js,ts}',
-    './pages/**/*.{vue,js,ts}',
-    './app.{vue,js,ts}',
-    './nuxt.config.{js,ts}'
+    "./components/**/*.{vue,js,ts}",
+    "./pages/**/*.{vue,js,ts}",
+    "./app.{vue,js,ts}",
+    "./nuxt.config.{js,ts}",
   ],
   theme: {
-    extend: {}
+    extend: {
+      fontFamily: {
+        script: ['"Great Vibes"', "cursive"],
+      },
+    },
   },
-  plugins: []
-}
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- Add Google Fonts link and Tailwind font family for graceful script typography
- Polish invitation card with hearts, gradients and hover effects
- Apply soft gradient background and serif base font across site

## Testing
- `npm run lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_689eeeff062c83318b802a957e1f633c